### PR TITLE
Expose bare to https://go.sillylittle.tech/bare/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,10 @@
 <sub>Powered by [<img width=18 src="https://vercel.com/favicon.ico"></img>](https://vercel.app)</sub>
 <svg aria-label="Vercel logomark" height="64" role="img" style="width: auto; overflow: visible;" viewBox="0 0 74 64"><path d="M37.5896 0.25L74.5396 64.25H0.639648L37.5896 0.25Z" fill="white"></path></svg>
 
+**Read the [Docs](https://docs.sillylittle.tech/setup/ezprox)\
+for setup instructions and...\
+important info!**\
+or use the public url @ https://prox.sillylittle.tech
+
 API Expects a http URL after the first trailing slash.
 Invalid URL will return error.

--- a/public/uv/uv.config.js
+++ b/public/uv/uv.config.js
@@ -1,7 +1,7 @@
 /*global Ultraviolet*/
 self.__uv$config = {
-  prefix: "/u/",
-  bare: "/bare/",
+  prefix: "/",
+  bare: "https://go.sillylittle.tech/bare/",
   handler: "/uv/uv.handler.js",
   client: "/uv/uv.client.js",
   bundle: "/uv/uv.bundle.js",


### PR DESCRIPTION
- Exposes UV config BARE to go.sillylittle.tech/bare/ to prevent / from overriding the bare server on current domain. 