### PR TITLE
[ Hotfix ] : Patch for Smart Browsers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,19 @@
 {
   "version": 2,
-  "builds": [{
+  "builds": [
+    {
       "src": "index.js",
       "use": "@vercel/node"
-  }],
-  "routes": [{
+    }
+  ],
+  "routes": [
+    {
       "src": "/(.*)",
       "dest": "index.js"
-  }]
+    },
+    {
+      "src": "/https:/(.*)",
+      "dest": "/https://$1"
+    }
+  ]
 }


### PR DESCRIPTION
- RFC 3986 is goofy, and causes browsers to sometimes ignore the second http request and treat it as a second level instead.
- This patch hopes to remedy that by also treating http:/ headers (improper) as correct https:// headers.